### PR TITLE
商品詳細機能

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ _ has_many :orders
 | status_id        | integer      | null: false                    |
 | shipping_id      | integer      | null: false                    |
 | delivery_area_id | integer      | null: false                    |
-| delivery_days_id | integer      | null: false                    |
+| delivery_day_id  | integer      | null: false                    |
 | price            | integer      | null: false                    |
 | user             | references   | null: false, foreign_key: true |
 

--- a/app/assets/stylesheets/items/show.css
+++ b/app/assets/stylesheets/items/show.css
@@ -1,0 +1,206 @@
+/* 商品の概要 */
+
+.item-show {
+  background-color: #f8f8f8;
+  width: 100vw;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 5vh 0;
+}
+
+.item-box {
+  background-color: #FFF;
+  width: 70vw;
+  min-width: 1200px;
+  padding: 10vh 15vw;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.item-box>.name {
+  text-align: center;
+  font-weight: bold;
+  font-size: 25px;
+}
+
+.item-box-img {
+  height: 50vh;
+  width: 60vw;
+  min-height: 500px;
+  background-color: rgb(205, 202, 202);
+  object-fit: contain;
+}
+
+.item-price-box {
+  margin: 25px 0px;
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+}
+
+.item-price-box>.item-price {
+  font-size: 4vh;
+  font-weight: bold;
+}
+
+.item-price-box>.item-postage {
+  font-size: 16px;
+}
+
+
+.item-red-btn {
+  text-align: center;
+  background-color: #ea352d;
+  font-size: 24px;
+  font-weight: bold;
+  color: #FFF;
+  margin: 20px 0px;
+  padding: 2vh 10vw;
+}
+
+.or-text {
+  font-size: 20px;
+}
+
+.item-destroy {
+  background-color: lightgray;
+  text-align: center;
+  font-size: 24px;
+  color: black;
+  margin: 20px 0px;
+  padding: 2vh 10vw;
+}
+
+.item-explain-box {
+  font-size: 18px;
+  margin: 40px 0px;
+}
+
+.detail-table {
+  margin-bottom: 30px;
+  width: 100%;
+}
+
+.detail-item {
+  width: 20%;
+  background-color: #eee;
+  border: 1px solid #dedede;
+  font-size: 14px;
+  text-align: center;
+}
+
+.detail-value {
+  width: 80%;
+  padding: 20px;
+  border: 1px solid #dedede;
+  font-size: 14px;
+}
+
+.option {
+  display: flex;
+  justify-content: space-between;
+  position: relative;
+}
+
+.favorite-btn {
+  border-radius: 40px;
+  width: 15vw;
+  min-width: 200px;
+  color: rgb(249, 75, 0);
+  border: 2px solid #ffb340;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-right: 20px;
+}
+
+.favorite-star-icon {
+  margin-right: 5px;
+}
+
+.report-btn {
+  border-radius: 40px;
+  width: 15vw;
+  min-width: 200px;
+
+  padding: 1vh 0;
+  color: black;
+  border: 2px solid #2d2d2d;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.report-flag-icon {
+  margin-right: 5px;
+}
+
+
+/* /商品の概要 */
+
+.comment-box {
+  width: 40vw;
+  background-color: #fff;
+  margin: 5vh 0;
+  text-align: center;
+}
+
+.comment-text {
+  width: 100%;
+  height: 100px;
+  padding: 10px;
+  border: solid 2px #dedede;
+  resize: none;
+}
+
+.comment-warn {
+  padding: 10px;
+  font-size: 14px;
+  margin: 10px 0px;
+  text-align: left;
+}
+
+.comment-btn {
+  line-height: 48px;
+  background-color: #3CCACE;
+  border: 1px solid #3CCACE;
+  color: #fff;
+  width: 50%;
+  min-width: 150px;
+  font-size: 18px;
+  border-radius: 100px;
+  margin-bottom: 2vh;
+}
+
+.comment-flag {
+  display: flex;
+  justify-content: center;
+}
+
+.comment-flag-icon {
+  margin: 10px 5px 0 0;
+}
+
+.links {
+  display: flex;
+  justify-content: space-between;
+  width: 50vw;
+
+}
+
+.change-item-btn {
+  font-size: 30px;
+  text-decoration: none;
+  color: #3CCACE;
+}
+
+.another-item {
+  display: block;
+  margin: 30px 0px 8px;
+  color: #3CCACE;
+  text-decoration: none;
+  font-weight: bold;
+  font-size: 23px;
+}

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -38,7 +38,7 @@ class ItemsController < ApplicationController
                                   :status_id,
                                   :shipping_id,
                                   :delivery_area_id,
-                                  :delivery_days_id,
+                                  :delivery_day_id,
                                   :price,
                                   :image
                                 ).merge(

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -23,6 +23,10 @@ class ItemsController < ApplicationController
     end
   end
 
+  #商品詳細ページ
+  def show
+  end
+
   private
 
   #ストロングパラメーターの設定

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -25,6 +25,7 @@ class ItemsController < ApplicationController
 
   #商品詳細ページ
   def show
+    @item = Item.find(params[:id])
   end
 
   private

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -27,7 +27,7 @@ class Item < ApplicationRecord
     validates :status_id
     validates :shipping_id
     validates :delivery_area_id
-    validates :delivery_days_id
+    validates :delivery_day_id
   end
 
   #validation not null 半角数字のみ カラムの型はinteger型のみ 最小値(300)、最大値(9,999,999)の制約

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -133,7 +133,7 @@
         <% @items.each do |item| %>
 
           <li class='list'>
-            <%= link_to "#" do %>
+            <%= link_to item_path(item.id) do %>
             <div class='item-img-content'>
               <%= image_tag item.image, class: "item-img" %>
 

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -79,7 +79,7 @@
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:delivery_days_id, DeliveryDay.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:delivery_day_id, DeliveryDay.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
     <%# /配送について %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,0 +1,108 @@
+<%= render "shared/header" %>
+
+<%# 商品の概要 %>
+<div class="item-show">
+  <div class="item-box">
+    <h2 class="name">
+      <%= "商品名" %>
+    </h2>
+    <div class='item-img-content'>
+      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%# 商品が売れている場合は、sold outを表示しましょう %>
+      <div class='sold-out'>
+        <span>Sold Out!!</span>
+      </div>
+      <%# //商品が売れている場合は、sold outを表示しましょう %>
+    </div>
+    <div class="item-price-box">
+      <span class="item-price">
+        ¥ 999,999,999
+      </span>
+      <span class="item-postage">
+        <%= '配送料負担' %>
+      </span>
+    </div>
+
+    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+
+    <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+    <p class='or-text'>or</p>
+    <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+
+    <%# 商品が売れていない場合はこちらを表示しましょう %>
+    <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+    <%# //商品が売れていない場合はこちらを表示しましょう %>
+
+
+    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+
+    <div class="item-explain-box">
+      <span><%= "商品説明" %></span>
+    </div>
+    <table class="detail-table">
+      <tbody>
+        <tr>
+          <th class="detail-item">出品者</th>
+          <td class="detail-value"><%= "出品者名" %></td>
+        </tr>
+        <tr>
+          <th class="detail-item">カテゴリー</th>
+          <td class="detail-value"><%= "カテゴリー名" %></td>
+        </tr>
+        <tr>
+          <th class="detail-item">商品の状態</th>
+          <td class="detail-value"><%= "商品の状態" %></td>
+        </tr>
+        <tr>
+          <th class="detail-item">配送料の負担</th>
+          <td class="detail-value"><%= "発送料の負担" %></td>
+        </tr>
+        <tr>
+          <th class="detail-item">発送元の地域</th>
+          <td class="detail-value"><%= "発送元の地域" %></td>
+        </tr>
+        <tr>
+          <th class="detail-item">発送日の目安</th>
+          <td class="detail-value"><%= "発送日の目安" %></td>
+        </tr>
+      </tbody>
+    </table>
+    <div class="option">
+      <div class="favorite-btn">
+        <%= image_tag "star.png" ,class:"favorite-star-icon" ,width:"20",height:"20"%>
+        <span>お気に入り 0</span>
+      </div>
+      <div class="report-btn">
+        <%= image_tag "flag.png" ,class:"report-flag-icon" ,width:"20",height:"20"%>
+        <span>不適切な商品の通報</span>
+      </div>
+    </div>
+  </div>
+  <%# /商品の概要 %>
+
+  <div class="comment-box">
+    <form>
+      <textarea class="comment-text"></textarea>
+      <p class="comment-warn">
+        相手のことを考え丁寧なコメントを心がけましょう。
+        <br>
+        不快な言葉遣いなどは利用制限や退会処分となることがあります。
+      </p>
+      <button type="submit" class="comment-btn">
+        <%= image_tag "comment.png" ,class:"comment-flag-icon" ,width:"20",height:"25"%>
+        <span>コメントする<span>
+      </button>
+    </form>
+  </div>
+  <div class="links">
+    <a href="#" class="change-item-btn">
+      ＜ 前の商品
+    </a>
+    <a href="#" class="change-item-btn">
+      後ろの商品 ＞
+    </a>
+  </div>
+  <a href="#" class='another-item'><%= "商品のカテゴリー名" %>をもっと見る</a>
+</div>
+
+<%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,10 +4,10 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.name %>
     </h2>
     <div class='item-img-content'>
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image ,class:"item-box-img" %>
       <div class='sold-out'>
         <%# 商品購入機能未実装なので実装後に追加 %>
         <%# if 購入されていた時の処理 %>
@@ -17,10 +17,10 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        <%= @item.price %>
       </span>
       <span class="item-postage">
-        <%= '配送料負担' %>
+        <%= @item.shipping.name %>
       </span>
     </div>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -24,16 +24,22 @@
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+    <%# ユーザーがログインしている時に行う処理 %>
+    <% if user_signed_in? %>
 
-    <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
-    <p class='or-text'>or</p>
-    <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+      <%# ログインしているユーザーが出品している商品の詳細ページへアクセスした時 %>
+      <% if current_user.id == @item.user_id %>
+        <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+        <p class='or-text'>or</p>
+        <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
 
-    <%# 商品が売れていない場合の処理、購入機能の未実装なので実装後追加 %>
-    <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+      <%# ログインしているが別のユーザーが出品している商品の詳細ページへアクセスした時 購入機能が未実装なので実装後機能を追加 %>
+      <%# elsif 商品が出品中かどうか判断する処理 %>
+        <%# <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
 
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+      <% end %>
+    <% end %>
+    <%# //ユーザーがログインしている時に行う処理 %>
 
     <div class="item-explain-box">
       <span><%= "商品説明" %></span>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -30,9 +30,8 @@
     <p class='or-text'>or</p>
     <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
 
-    <%# 商品が売れていない場合の処理、購入機の未実装なので実装後追加 %>
-    <%# <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
-
+    <%# 商品が売れていない場合の処理、購入機能の未実装なので実装後追加 %>
+    <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
 
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
@@ -43,27 +42,27 @@
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.status.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.shipping.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.delivery_area.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= "@item.delivery_day.name" %></td>
         </tr>
       </tbody>
     </table>
@@ -102,7 +101,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <a href="#" class='another-item'><%= "商品のカテゴリー名" %>をもっと見る</a>
+  <a href="#" class='another-item'><%= @item.category.name %>をもっと見る</a>
 </div>
 
 <%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -8,11 +8,12 @@
     </h2>
     <div class='item-img-content'>
       <%= image_tag "item-sample.png" ,class:"item-box-img" %>
-      <%# 商品が売れている場合は、sold outを表示しましょう %>
       <div class='sold-out'>
-        <span>Sold Out!!</span>
+        <%# 商品購入機能未実装なので実装後に追加 %>
+        <%# if 購入されていた時の処理 %>
+          <%# <span>Sold Out!!</span> %>
+        <%# end %>
       </div>
-      <%# //商品が売れている場合は、sold outを表示しましょう %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
@@ -29,9 +30,8 @@
     <p class='or-text'>or</p>
     <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
 
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
+    <%# 商品が売れていない場合の処理、購入機の未実装なので実装後追加 %>
+    <%# <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
 
 
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -68,7 +68,7 @@
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "@item.delivery_day.name" %></td>
+          <td class="detail-value"><%= @item.delivery_day.name %></td>
         </tr>
       </tbody>
     </table>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -42,7 +42,7 @@
     <%# //ユーザーがログインしている時に行う処理 %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.explanation %></span>
     </div>
     <table class="detail-table">
       <tbody>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'items#index'
-  resources :items, only: [:index, :new, :create]
+  resources :items, only: [:index, :new, :create, :show]
 end

--- a/db/migrate/20201105065726_create_items.rb
+++ b/db/migrate/20201105065726_create_items.rb
@@ -7,7 +7,7 @@ class CreateItems < ActiveRecord::Migration[6.0]
       t.integer     :status_id
       t.integer     :shipping_id
       t.integer     :delivery_area_id
-      t.integer     :delivery_days_id
+      t.integer     :delivery_day_id
       t.integer     :price
       t.references  :user
       t.timestamps

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -40,7 +40,7 @@ ActiveRecord::Schema.define(version: 2020_11_05_072434) do
     t.integer "status_id"
     t.integer "shipping_id"
     t.integer "delivery_area_id"
-    t.integer "delivery_days_id"
+    t.integer "delivery_day_id"
     t.integer "price"
     t.bigint "user_id"
     t.datetime "created_at", precision: 6, null: false


### PR DESCRIPTION
# WHAT
商品詳細機能の実装
## WHY
トップページに一覧表示された、商品をクリックした時その商品の詳細ページへと遷移する
遷移した先のページではユーザーの状態に応じて表示を変更する様に実装する
商品購入機能未実装のため売却済みの商品に関する記述は未実装になっている
### ログインしていない時
商品の詳細ページへ遷移することはできる。編集、削除、商品を購入するためのボタンは表示されない
https://gyazo.com/cd1f8f69e496051b333000fdb403498a
### ログインしている時
#### ログインしているユーザーが出品した商品の詳細ページに遷移した時
編集、削除ボタンが表示される様になっている
https://gyazo.com/86e9384d0a9b7b57508ce2b02cb0b735
#### ログインしているユーザーとは別のユーザーが出品した商品の詳細ページへ遷移した時
本来は商品を購入するためのボタンが表示されているが今回の実装では購入機能がまだ未実装なのでボタンは表示されていない。編集、削除のボタンが表示されない部分のみ実装済み
https://gyazo.com/79cfb5cdcb7a46c3a4664672c2f91add
#### 未実装の商品購入済みの時に表示する機能のコード部分
本来表示される購入画面へ遷移するためのボタンをコメントアウトしている
https://gyazo.com/d05545ddb477147dc828b13c1eee4577