### PR TITLE
商品編集機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -32,6 +32,20 @@ class ItemsController < ApplicationController
   #商品編集ページ
   def edit
     @item = Item.find(params[:id])
+    
+    #URLを直接指定された時の処理にログインしているかどうかを判断する
+    if user_signed_in?
+      
+      #出品者とは違うユーザーが編集ページへ遷移しようとした時はトップページへ遷移する
+      unless current_user.id == @item.user_id
+        redirect_to root_path
+      end
+
+    else
+      #ログインしていなユーザーはログインページへ遷移する
+      redirect_to new_user_session_path
+    end
+
   end
 
   #データベースの情報を更新する

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -26,12 +26,12 @@ class ItemsController < ApplicationController
 
   #商品詳細ページ
   def show
-    @item = Item.find(params[:id])
+    set_item_find
   end
 
   #商品編集ページ
   def edit
-    @item = Item.find(params[:id])
+    set_item_find
 
     #出品者とは違うユーザーが編集ページへ遷移しようとした時はトップページへ遷移する
     unless current_user.id == @item.user_id
@@ -42,7 +42,7 @@ class ItemsController < ApplicationController
 
   #データベースの情報を更新する
   def update
-    @item = Item.find(params[:id])
+    set_item_find
     if @item.update(item_params)
       redirect_to action: :show
     else
@@ -68,4 +68,10 @@ class ItemsController < ApplicationController
                                   user_id: current_user.id
                                 )
   end
+
+  #Itemモデルの特定のテーブルの値を取得
+  def set_item_find
+    @item = Item.find(params[:id])
+  end
+
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -28,6 +28,14 @@ class ItemsController < ApplicationController
     @item = Item.find(params[:id])
   end
 
+  #商品編集ページ
+  def edit
+  end
+
+  #編集した情報をアップデートする
+  def update
+  end
+
   private
 
   #ストロングパラメーターの設定

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -13,6 +13,7 @@ class ItemsController < ApplicationController
     @item = Item.new
   end
 
+  #データベースへ値を保存する
   def create
     @item = Item.new(item_params)
     if @item.save
@@ -30,9 +31,10 @@ class ItemsController < ApplicationController
 
   #商品編集ページ
   def edit
+    @item = Item.find(params[:id])
   end
 
-  #編集した情報をアップデートする
+  #データベースの情報を更新する
   def update
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -3,6 +3,9 @@ class ItemsController < ApplicationController
   #特定のアクションにのみログインしていない場合はログイン画面に遷移する処理を行う
   before_action :authenticate_user!, only: [:new, :edit]
 
+  #モデルのインスタンスの生成
+  before_action :set_item_find, only: [:show, :edit, :update]
+
   #top page
   def index
     @items = Item.all.order(id: :DESC)
@@ -26,12 +29,10 @@ class ItemsController < ApplicationController
 
   #商品詳細ページ
   def show
-    set_item_find
   end
 
   #商品編集ページ
   def edit
-    set_item_find
 
     #出品者とは違うユーザーが編集ページへ遷移しようとした時はトップページへ遷移する
     unless current_user.id == @item.user_id
@@ -42,7 +43,6 @@ class ItemsController < ApplicationController
 
   #データベースの情報を更新する
   def update
-    set_item_find
     if @item.update(item_params)
       redirect_to action: :show
     else

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
 
-  #ログインしていない場合出品画面には遷移せず、ログイン画面に遷移する
-  before_action :authenticate_user!, only: [:new]
+  #特定のアクションにのみログインしていない場合はログイン画面に遷移する処理を行う
+  before_action :authenticate_user!, only: [:new, :edit]
 
   #top page
   def index
@@ -32,18 +32,10 @@ class ItemsController < ApplicationController
   #商品編集ページ
   def edit
     @item = Item.find(params[:id])
-    
-    #URLを直接指定された時の処理にログインしているかどうかを判断する
-    if user_signed_in?
-      
-      #出品者とは違うユーザーが編集ページへ遷移しようとした時はトップページへ遷移する
-      unless current_user.id == @item.user_id
-        redirect_to root_path
-      end
 
-    else
-      #ログインしていなユーザーはログインページへ遷移する
-      redirect_to new_user_session_path
+    #出品者とは違うユーザーが編集ページへ遷移しようとした時はトップページへ遷移する
+    unless current_user.id == @item.user_id
+      redirect_to root_path
     end
 
   end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -36,6 +36,13 @@ class ItemsController < ApplicationController
 
   #データベースの情報を更新する
   def update
+    @item = Item.find(params[:id])
+    if @item.update(item_params)
+      redirect_to action: :show
+    else
+      @item.valid?
+      render :edit
+    end
   end
 
   private

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -139,7 +139,7 @@ app/assets/stylesheets/items/new.css %>
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
       <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', "#", class:"back-btn" %>
+      <%=link_to 'もどる', item_path(@item.id), class:"back-btn" %>
     </div>
     <%# /下部ボタン %>
   </div>

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -1,0 +1,161 @@
+<%# cssは商品出品のものを併用しています。
+app/assets/stylesheets/items/new.css %>
+
+<div class="items-sell-contents">
+  <header class="items-sell-header">
+    <%= link_to image_tag('furima-logo-color.png' , size: '185x50'), "/" %>
+  </header>
+  <div class="items-sell-main">
+    <h2 class="items-sell-title">商品の情報を入力</h2>
+    <%= form_with local: true do |f| %>
+
+    <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
+    <%# render 'shared/error_messages', model: f.object %>
+    <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
+
+    <%# 出品画像 %>
+    <div class="img-upload">
+      <div class="weight-bold-text">
+        出品画像
+        <span class="indispensable">必須</span>
+      </div>
+      <div class="click-upload">
+        <p>
+          クリックしてファイルをアップロード
+        </p>
+        <%= f.file_field :hoge, id:"item-image" %>
+      </div>
+    </div>
+    <%# /出品画像 %>
+    <%# 商品名と商品説明 %>
+    <div class="new-items">
+      <div class="weight-bold-text">
+        商品名
+        <span class="indispensable">必須</span>
+      </div>
+      <%= f.text_area :hoge, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+      <div class="items-explain">
+        <div class="weight-bold-text">
+          商品の説明
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.text_area :hoge, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+      </div>
+    </div>
+    <%# /商品名と商品説明 %>
+
+    <%# 商品の詳細 %>
+    <div class="items-detail">
+      <div class="weight-bold-text">商品の詳細</div>
+      <div class="form">
+        <div class="weight-bold-text">
+          カテゴリー
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-category"}) %>
+        <div class="weight-bold-text">
+          商品の状態
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-sales-status"}) %>
+      </div>
+    </div>
+    <%# /商品の詳細 %>
+
+    <%# 配送について %>
+    <div class="items-detail">
+      <div class="weight-bold-text question-text">
+        <span>配送について</span>
+        <a class="question" href="#">?</a>
+      </div>
+      <div class="form">
+        <div class="weight-bold-text">
+          配送料の負担
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <div class="weight-bold-text">
+          発送元の地域
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-prefecture"}) %>
+        <div class="weight-bold-text">
+          発送までの日数
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+      </div>
+    </div>
+    <%# /配送について %>
+
+    <%# 販売価格 %>
+    <div class="sell-price">
+      <div class="weight-bold-text question-text">
+        <span>販売価格<br>(¥300〜9,999,999)</span>
+        <a class="question" href="#">?</a>
+      </div>
+      <div>
+        <div class="price-content">
+          <div class="price-text">
+            <span>価格</span>
+            <span class="indispensable">必須</span>
+          </div>
+          <span class="sell-yen">¥</span>
+          <%= f.text_field :hoge, class:"price-input", id:"item-price", placeholder:"例）300" %>
+        </div>
+        <div class="price-content">
+          <span>販売手数料 (10%)</span>
+          <span>
+            <span id='add-tax-price'></span>円
+          </span>
+        </div>
+        <div class="price-content">
+          <span>販売利益</span>
+          <span>
+            <span id='profit'></span>円
+          </span>
+        </div>
+      </div>
+    </div>
+    <%# /販売価格 %>
+
+    <%# 注意書き %>
+    <div class="caution">
+      <p class="sentence">
+        <a href="#">禁止されている出品、</a>
+        <a href="#">行為</a>
+        を必ずご確認ください。
+      </p>
+      <p class="sentence">
+        またブランド品でシリアルナンバー等がある場合はご記載ください。
+        <a href="#">偽ブランドの販売</a>
+        は犯罪であり処罰される可能性があります。
+      </p>
+      <p class="sentence">
+        また、出品をもちまして
+        <a href="#">加盟店規約</a>
+        に同意したことになります。
+      </p>
+    </div>
+    <%# /注意書き %>
+    <%# 下部ボタン %>
+    <div class="sell-btn-contents">
+      <%= f.submit "変更する" ,class:"sell-btn" %>
+      <%=link_to 'もどる', "#", class:"back-btn" %>
+    </div>
+    <%# /下部ボタン %>
+  </div>
+  <% end %>
+
+  <footer class="items-sell-footer">
+    <ul class="menu">
+      <li><a href="#">プライバシーポリシー</a></li>
+      <li><a href="#">フリマ利用規約</a></li>
+      <li><a href="#">特定商取引に関する表記</a></li>
+    </ul>
+    <%= link_to image_tag('furima-logo-color.png' , size: '185x50'), "/" %>
+    <p class="inc">
+      ©︎Furima,Inc.
+    </p>
+  </footer>
+</div>

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -7,11 +7,9 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with local: true do |f| %>
+    <%= form_with model: @item, local: true do |f| %>
 
-    <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-    <%# render 'shared/error_messages', model: f.object %>
-    <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
+    <%= render 'shared/error_messages', model: f.object %>
 
     <%# 出品画像 %>
     <div class="img-upload">
@@ -23,7 +21,7 @@ app/assets/stylesheets/items/new.css %>
         <p>
           クリックしてファイルをアップロード
         </p>
-        <%= f.file_field :hoge, id:"item-image" %>
+        <%= f.file_field :image, id:"item-image" %>
       </div>
     </div>
     <%# /出品画像 %>
@@ -33,13 +31,13 @@ app/assets/stylesheets/items/new.css %>
         商品名
         <span class="indispensable">必須</span>
       </div>
-      <%= f.text_area :hoge, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+      <%= f.text_area :name, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
       <div class="items-explain">
         <div class="weight-bold-text">
           商品の説明
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_area :hoge, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+        <%= f.text_area :explanation, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
       </div>
     </div>
     <%# /商品名と商品説明 %>
@@ -52,12 +50,12 @@ app/assets/stylesheets/items/new.css %>
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-category"}) %>
+        <%= f.collection_select(:category_id, Category.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-sales-status"}) %>
+        <%= f.collection_select(:status_id, Status.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
       </div>
     </div>
     <%# /商品の詳細 %>
@@ -73,17 +71,17 @@ app/assets/stylesheets/items/new.css %>
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <%= f.collection_select(:shipping_id, Shipping.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-prefecture"}) %>
+        <%= f.collection_select(:delivery_area_id, DeliveryArea.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:delivery_day_id, DeliveryDay.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
     <%# /配送について %>
@@ -101,7 +99,7 @@ app/assets/stylesheets/items/new.css %>
             <span class="indispensable">必須</span>
           </div>
           <span class="sell-yen">¥</span>
-          <%= f.text_field :hoge, class:"price-input", id:"item-price", placeholder:"例）300" %>
+          <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
         </div>
         <div class="price-content">
           <span>販売手数料 (10%)</span>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -29,7 +29,7 @@
 
       <%# ログインしているユーザーが出品している商品の詳細ページへアクセスした時 %>
       <% if current_user.id == @item.user_id %>
-        <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+        <%= link_to '商品の編集', edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
         <p class='or-text'>or</p>
         <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'items#index'
-  resources :items, only: [:index, :new, :create, :show]
+  resources :items, only: [:index, :new, :create, :show, :edit, :update]
 end


### PR DESCRIPTION
# WHAT
商品編集機能の実装
## WHY
出品者が商品詳細ページ内の編集ボタンを押す事で商品の編集ページに遷移する事ができる
商品編集ページでは商品を出品する画面とほぼ同じ画面構成になっている
商品編集ページでは出品時に登録したデータが商品編集画面遷移後すぐに表示されている
画像が空の状態で編集内容を更新しても元々投稿していた画像は空にならない
何も編集せずに更新しても画像などのデータは空にならない
ユーザーの状態によって画面の遷移を変える
売却済みの商品に対する画面遷移処理は購入機能実装後に機能を追加するため今回は未実装
### 出品者は編集ボタンを押す事で商品編集画面へと遷移し、尚且つあらかじめ保存されていたデータが表示されている。
ただし画像の情報が初期状態では空になっているのは仕様です。
https://gyazo.com/c652a7625623252bd14eb2913afe51af
#### この時に表示される画面は商品出品画面とほぼ似ている必要があるので、商品出品画面の内容を表示
https://gyazo.com/65e2df8144a5a99184a9e78ca30e0a7a
### 編集せずに更新しても値は変更されない
初期状態では画像の情報は空ですが問題なく更新され、画像の情報も空にならない事を確認できる
https://gyazo.com/109605bf147062c6e7781a32e15e1f61
### 間違った値が更新された時編集画面に留まり、エラーメッセージが表示される
https://gyazo.com/3edef524417e1839dbfbcfad4b758bdd
### ユーザーが直接URLを指定して画面遷移しようとした時の処理
この時ログインしていて、ユーザーが出品した商品の画面に遷移した時はそのまま表示される
https://gyazo.com/ba4b7e6c7a445e5946dc6a4d21bcab64
#### ログインしていない時はログインページへ遷移する
https://gyazo.com/5b6e590965de95f68a910a965c7502f7
#### 出品者ではないユーザーが商品の編集ページへ遷移しようとした時トップページへ遷移する
https://gyazo.com/103e5062671f7cdb1c79a8d2c722de61